### PR TITLE
export UAdCollectionBPLibrary for C++

### DIFF
--- a/Plugins/AdCollection/Source/AdCollection/Public/AdCollectionBPLibrary.h
+++ b/Plugins/AdCollection/Source/AdCollection/Public/AdCollectionBPLibrary.h
@@ -56,7 +56,7 @@ struct FRewardedStatus
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FPlayRewardedDelegate, FRewardedStatus, RewardStatus);
 
 UCLASS()
-class UAdCollectionBPLibrary : public UBlueprintFunctionLibrary
+class ADCOLLECTION_API UAdCollectionBPLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_UCLASS_BODY()
 


### PR DESCRIPTION
this tiny change is needed to make the UAdCollectionBPLibrary functions accessible from other c++ modules