### PR TITLE
display warning for iOS AdMob problem

### DIFF
--- a/Plugins/AdCollection/Source/AdMob/Private/IOS/AdMobIOS.cpp
+++ b/Plugins/AdCollection/Source/AdMob/Private/IOS/AdMobIOS.cpp
@@ -10,6 +10,8 @@
 
 void FAdMobModule::ShowBanner(enAdsBannerPos pos)
 {
+    if(!IsBannerReady()) UE_LOG(LogTemp, Warning, TEXT("AdMob on iOS will not display uncached banners."));
+
     UIViewController* curViewController = (UIViewController*)[IOSAppDelegate GetDelegate].IOSController;
 
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
If one tries to display an AdMob banner ad on iOS, before the ad has finished caching, then it will pretend to show the ad and post to /adview, but not actually show the ad. The solution is to wait until a banner ad has been cached, and then call ShowBanner. Log a warning if someone tries to do otherwise.